### PR TITLE
[Power Support] Make a separate script to build bosh-davcli on Power platform.

### DIFF
--- a/bin/build-linux-ppc64le
+++ b/bin/build-linux-ppc64le
@@ -1,0 +1,15 @@
+#!/bin/bash 
+
+set -e
+
+bin=$(dirname $0)
+
+export GOROOT=/usr/local/gccgo
+export PATH=$GOROOT/bin:$PATH
+export LD_LIBRARY_PATH=$GOROOT/lib64
+export buld_options="-compiler gccgo -gccgoflags '-static-libgo'"
+
+# we need following steps to make gccgo work
+cp -f $GOROOT/lib64/libgo.so.7 /lib/powerpc64le-linux-gnu
+
+$bin/go build -o $bin/../out/dav-cli github.com/cloudfoundry/bosh-davcli/main

--- a/bin/build-linux-ppc64le
+++ b/bin/build-linux-ppc64le
@@ -7,9 +7,9 @@ bin=$(dirname $0)
 export GOROOT=/usr/local/gccgo
 export PATH=$GOROOT/bin:$PATH
 export LD_LIBRARY_PATH=$GOROOT/lib64
-export buld_options="-compiler gccgo -gccgoflags '-static-libgo'"
+export build_options="-compiler gccgo -gccgoflags '-static-libgo'"
 
 # we need following steps to make gccgo work
 cp -f $GOROOT/lib64/libgo.so.7 /lib/powerpc64le-linux-gnu
 
-$bin/go build -o $bin/../out/dav-cli github.com/cloudfoundry/bosh-davcli/main
+$bin/go build $build_options -o $bin/../out/dav-cli github.com/cloudfoundry/bosh-davcli/main


### PR DESCRIPTION
This script allows to build bosh-davcli on a Power system.

You can follow details in this PR https://github.com/cloudfoundry/bosh-agent/pull/24.
