### PR TITLE
Optional blobstore agent creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ To update dependencies, use `gvt update`. Here is a typical invocation to update
 gvt update github.com/cloudfoundry/bosh-utils
 ```
 
+### Run tests
+
+You can run the unit test with `ginkgo` as follows.
+
+```
+ginkgo -r -race -progress -mod vendor .
+```
 
 # Pre-signed URLs
 

--- a/client/client.go
+++ b/client/client.go
@@ -170,7 +170,9 @@ func (c client) createReq(method, blobID string, body io.Reader) (*http.Request,
 		return req, err
 	}
 
-	req.SetBasicAuth(c.config.User, c.config.Password)
+	if c.config.User != "" {
+		req.SetBasicAuth(c.config.User, c.config.Password)
+	}
 	return req, nil
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Client", func() {
 				Expect(req.Header.Get("Authorization")).NotTo(BeEmpty())
 			})
 
-			Context("when no user nor password is provided in blobstore options", func() {
+			Context("when neither user nor password is provided in blobstore options", func() {
 				BeforeEach(func() {
 					config.User = ""
 					config.Password = ""

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -201,6 +201,38 @@ var _ = Describe("Client", func() {
 				)
 				itUploadsABlob()
 			})
+
+			It("adds an Authorizatin header to the request", func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.RespondWith(204, ""),
+						ghttp.VerifyBody([]byte("content")),
+					),
+				)
+				itUploadsABlob()
+				req := server.ReceivedRequests()[0]
+				Expect(req.Header.Get("Authorization")).NotTo(BeEmpty())
+			})
+
+			Context("when no user nor password is provided in blobstore options", func() {
+				BeforeEach(func() {
+					config.User = ""
+					config.Password = ""
+					client = NewClient(config, httpclient.DefaultClient, logger)
+				})
+
+				It("sends a request with no Basic Auth header", func() {
+					server.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.RespondWith(204, ""),
+							ghttp.VerifyBody([]byte("content")),
+						),
+					)
+					itUploadsABlob()
+					req := server.ReceivedRequests()[0]
+					Expect(req.Header.Get("Authorization")).To(BeEmpty())
+				})
+			})
 		})
 
 		Context("when the http request fails", func() {

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -23,8 +23,6 @@ var _ = Describe("Signer", func() {
 
 		It("Generates a properly formed URL", func() {
 			actual, err := signer.GenerateSignedURL(path, objectID, verb, timeStamp, duration)
-			fmt.Println(actual)
-			fmt.Println(expected)
 			Expect(err).To(BeNil())
 			Expect(actual).To(Equal(expected))
 		})


### PR DESCRIPTION
When signed URLs are enabled on the Director's blobstore, then agent credentials for accessing the blobstore should be removed from the Director's deployment manifest.

This PR relates to the following work:
- cloudfoundry/bosh#2327
- cloudfoundry/bosh-deployment#423
- cloudfoundry/docs-bosh#755
- cloudfoundry/bosh-aws-cpi-release#118
- cloudfoundry/bosh-google-cpi-release#327
- cloudfoundry/bosh-azure-cpi-release#642
- cloudfoundry-incubator/bosh-alicloud-cpi-release#148
- cloudfoundry/bosh-openstack-cpi-release#242

It turns out that the Bosh Agent picks blobstore options from `properties.agent.env.bosh.blobstores[0].options` (as expressed in the Bosh deployment manifest) and send them _as-is_ to this `bosh-davcli` utility.

Thus when ensuring that the Bosh Agent supports optional agent credentials for accessing the blobstore, we only need `bosh-davcli` to support optional agent credentials. That's the goal of this PR.

The result is that when no `user` property is specified, then no `Authorization` header is added, resulting in no Basic Auth in the request. This is consistent with rules we've implemented in the the jobs of the `bosh` release: password is mandatory only when user is specified.

Here I've added the necessary tests to cover the feature. Doing that, I've updated the documentation for running tests, and fixed some issued with test output being messed up by some `fmt.Print()` output.